### PR TITLE
Accept either NAGIOS or ICINGA env variables.

### DIFF
--- a/nagios.pl
+++ b/nagios.pl
@@ -82,7 +82,7 @@ my %event;
 
 # Get all Nagios variables
 while ((my $k, my $v) = each %ENV) {
-	next unless $k =~ /^NAGIOS_(.*)$/;
+	next unless $k =~ /^NAGIOS|ICINGA_(.*)$/;
 	$event{$1} = $v;
 }
 


### PR DESCRIPTION
Our instance of Nagios uses NAGIOS as a ENV pre-pend instead of ICINGA. Probably that way for a bunch of users, accept either NAGIOS or ICINGA env variables.
