### PR TITLE
Add paren to capture $1 properly

### DIFF
--- a/nagios.pl
+++ b/nagios.pl
@@ -82,7 +82,7 @@ my %event;
 
 # Get all Nagios variables
 while ((my $k, my $v) = each %ENV) {
-	next unless $k =~ /^NAGIOS|ICINGA_(.*)$/;
+	next unless $k =~ /^(?:NAGIOS|ICINGA)_(.*)$/;
 	$event{$1} = $v;
 }
 


### PR DESCRIPTION
It need this paren to match with "NAGIOS_FOO" type variable name.
