### PR TITLE
Add support for proxy from environment variable

### DIFF
--- a/nagios.pl
+++ b/nagios.pl
@@ -99,6 +99,7 @@ $event{"slack_version"} = "1.1";
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(15);
+$ua->env_proxy;
 
 my $req = POST("https://${opt_domain}/services/hooks/nagios?token=${opt_token}", \%event);
 


### PR DESCRIPTION
This tiny change allows one to use env `http_proxy` or `https_proxy` settings if they exist.

